### PR TITLE
Add API rate limiting

### DIFF
--- a/apps/TimeLine/src/app/api/db-status/route.ts
+++ b/apps/TimeLine/src/app/api/db-status/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from 'next/server'
+import { applyRateLimitHeaders, checkRateLimit, createRateLimitResponse } from '@/lib/api-rate-limit'
 import { getTimelineDb } from '@/lib/d1'
 
-export async function GET() {
+export async function GET(request: Request) {
+  const rateLimit = { key: 'db-status', limit: 20, windowMs: 60_000 }
+  const limitResult = checkRateLimit(request, rateLimit)
+  if (!limitResult.allowed) return createRateLimitResponse(rateLimit, limitResult.resetAt)
+
   const db = getTimelineDb()
 
   const [tablesResult, roomsCountResult, eventsCountResult] = await Promise.all([
@@ -12,11 +17,16 @@ export async function GET() {
     db.prepare('SELECT COUNT(*) AS count FROM schedule_events').all<{ count: number }>().catch(() => ({ results: [] })),
   ])
 
-  return NextResponse.json({
-    ok: true,
-    binding: 'ACADEMIC_TIMELINE_DB',
-    tables: tablesResult.results.map((table: { name: string }) => table.name),
-    roomCount: roomsCountResult.results[0]?.count ?? 0,
-    scheduleEventCount: eventsCountResult.results[0]?.count ?? 0,
-  })
+  return applyRateLimitHeaders(
+    NextResponse.json({
+      ok: true,
+      binding: 'ACADEMIC_TIMELINE_DB',
+      tables: tablesResult.results.map((table: { name: string }) => table.name),
+      roomCount: roomsCountResult.results[0]?.count ?? 0,
+      scheduleEventCount: eventsCountResult.results[0]?.count ?? 0,
+    }),
+    rateLimit,
+    limitResult.remaining,
+    limitResult.resetAt
+  )
 }

--- a/apps/TimeLine/src/app/api/events/route.ts
+++ b/apps/TimeLine/src/app/api/events/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from 'next/server'
+import { applyRateLimitHeaders, checkRateLimit, createRateLimitResponse } from '@/lib/api-rate-limit'
 import { listScheduleEvents } from '@/lib/timeline-rest'
 
 export async function GET(request: Request) {
+  const rateLimit = { key: 'events', limit: 60, windowMs: 60_000 }
+  const result = checkRateLimit(request, rateLimit)
+  if (!result.allowed) return createRateLimitResponse(rateLimit, result.resetAt)
+
   const { searchParams } = new URL(request.url)
   const events = await listScheduleEvents({
     roomId: searchParams.get('roomId'),
@@ -9,5 +14,5 @@ export async function GET(request: Request) {
     instructor: searchParams.get('instructor'),
   })
 
-  return NextResponse.json({ events })
+  return applyRateLimitHeaders(NextResponse.json({ events }), rateLimit, result.remaining, result.resetAt)
 }

--- a/apps/TimeLine/src/app/api/hello/route.ts
+++ b/apps/TimeLine/src/app/api/hello/route.ts
@@ -1,3 +1,9 @@
-export async function GET(_request: Request) {
-  return new Response('Hello, from API!');
+import { applyRateLimitHeaders, checkRateLimit, createRateLimitResponse } from '@/lib/api-rate-limit'
+
+export async function GET(request: Request) {
+  const rateLimit = { key: 'hello', limit: 30, windowMs: 60_000 }
+  const limitResult = checkRateLimit(request, rateLimit)
+  if (!limitResult.allowed) return createRateLimitResponse(rateLimit, limitResult.resetAt)
+
+  return applyRateLimitHeaders(new Response('Hello, from API!'), rateLimit, limitResult.remaining, limitResult.resetAt)
 }

--- a/apps/TimeLine/src/app/api/rooms/[roomId]/route.ts
+++ b/apps/TimeLine/src/app/api/rooms/[roomId]/route.ts
@@ -1,13 +1,23 @@
 import { NextResponse } from 'next/server'
+import { applyRateLimitHeaders, checkRateLimit, createRateLimitResponse } from '@/lib/api-rate-limit'
 import { getRoomDetail } from '@/lib/timeline-rest'
 
-export async function GET(_request: Request, context: { params: Promise<{ roomId: string }> }) {
+export async function GET(request: Request, context: { params: Promise<{ roomId: string }> }) {
+  const rateLimit = { key: 'room-detail', limit: 90, windowMs: 60_000 }
+  const limitResult = checkRateLimit(request, rateLimit)
+  if (!limitResult.allowed) return createRateLimitResponse(rateLimit, limitResult.resetAt)
+
   const { roomId } = await context.params
   const result = await getRoomDetail(roomId)
 
   if (!result) {
-    return NextResponse.json({ error: 'Room not found' }, { status: 404 })
+    return applyRateLimitHeaders(
+      NextResponse.json({ error: 'Room not found' }, { status: 404 }),
+      rateLimit,
+      limitResult.remaining,
+      limitResult.resetAt
+    )
   }
 
-  return NextResponse.json(result)
+  return applyRateLimitHeaders(NextResponse.json(result), rateLimit, limitResult.remaining, limitResult.resetAt)
 }

--- a/apps/TimeLine/src/app/api/rooms/route.ts
+++ b/apps/TimeLine/src/app/api/rooms/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from 'next/server'
+import { applyRateLimitHeaders, checkRateLimit, createRateLimitResponse } from '@/lib/api-rate-limit'
 import { listRooms } from '@/lib/timeline-rest'
 
 export async function GET(request: Request) {
+  const rateLimit = { key: 'rooms', limit: 60, windowMs: 60_000 }
+  const result = checkRateLimit(request, rateLimit)
+  if (!result.allowed) return createRateLimitResponse(rateLimit, result.resetAt)
+
   const { searchParams } = new URL(request.url)
   const rooms = await listRooms({
     floor: searchParams.get('floor'),
@@ -9,5 +14,5 @@ export async function GET(request: Request) {
     search: searchParams.get('search'),
   })
 
-  return NextResponse.json({ rooms })
+  return applyRateLimitHeaders(NextResponse.json({ rooms }), rateLimit, result.remaining, result.resetAt)
 }

--- a/apps/TimeLine/src/app/api/seed/route.ts
+++ b/apps/TimeLine/src/app/api/seed/route.ts
@@ -1,8 +1,13 @@
 import { NextResponse } from 'next/server'
+import { applyRateLimitHeaders, checkRateLimit, createRateLimitResponse } from '@/lib/api-rate-limit'
 import { seedTimelineDatabase } from '@/lib/timeline-rest'
 
 export async function POST(request: Request) {
+  const rateLimit = { key: 'seed', limit: 5, windowMs: 10 * 60_000 }
+  const limitResult = checkRateLimit(request, rateLimit)
+  if (!limitResult.allowed) return createRateLimitResponse(rateLimit, limitResult.resetAt)
+
   const body = (await request.json().catch(() => ({}))) as { reset?: boolean }
   const result = await seedTimelineDatabase({ reset: body.reset === true })
-  return NextResponse.json(result)
+  return applyRateLimitHeaders(NextResponse.json(result), rateLimit, limitResult.remaining, limitResult.resetAt)
 }

--- a/apps/TimeLine/src/lib/api-rate-limit.ts
+++ b/apps/TimeLine/src/lib/api-rate-limit.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server'
+
+type RateLimitOptions = {
+  key: string
+  limit: number
+  windowMs: number
+}
+
+type RateLimitEntry = {
+  count: number
+  resetAt: number
+}
+
+const globalRateLimit = globalThis as typeof globalThis & {
+  __timelineRateLimitStore__?: Map<string, RateLimitEntry>
+}
+
+const store = globalRateLimit.__timelineRateLimitStore__ ?? new Map<string, RateLimitEntry>()
+globalRateLimit.__timelineRateLimitStore__ = store
+
+function getClientIp(request: Request): string {
+  return (
+    request.headers.get('cf-connecting-ip') ??
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    request.headers.get('x-real-ip') ??
+    'anonymous'
+  )
+}
+
+export function checkRateLimit(request: Request, options: RateLimitOptions) {
+  const now = Date.now()
+  const storeKey = `${options.key}:${getClientIp(request)}`
+  const current = store.get(storeKey)
+
+  if (!current || current.resetAt <= now) {
+    const next = { count: 1, resetAt: now + options.windowMs }
+    store.set(storeKey, next)
+    return { allowed: true, remaining: options.limit - 1, resetAt: next.resetAt }
+  }
+
+  if (current.count >= options.limit) {
+    return { allowed: false, remaining: 0, resetAt: current.resetAt }
+  }
+
+  current.count += 1
+  return { allowed: true, remaining: options.limit - current.count, resetAt: current.resetAt }
+}
+
+export function createRateLimitResponse(options: RateLimitOptions, resetAt: number) {
+  return NextResponse.json(
+    { error: 'Too many requests', message: 'Please try again shortly.' },
+    {
+      status: 429,
+      headers: {
+        'Retry-After': String(Math.max(1, Math.ceil((resetAt - Date.now()) / 1000))),
+        'X-RateLimit-Limit': String(options.limit),
+        'X-RateLimit-Remaining': '0',
+        'X-RateLimit-Reset': String(Math.floor(resetAt / 1000)),
+      },
+    }
+  )
+}
+
+export function applyRateLimitHeaders(response: Response, options: RateLimitOptions, remaining: number, resetAt: number) {
+  response.headers.set('X-RateLimit-Limit', String(options.limit))
+  response.headers.set('X-RateLimit-Remaining', String(remaining))
+  response.headers.set('X-RateLimit-Reset', String(Math.floor(resetAt / 1000)))
+  return response
+}


### PR DESCRIPTION
## Summary

`TimeLine` app-ийн API route-ууд дээр энгийн rate limiting нэмлээ. Ингэснээр богино хугацаанд хэт олон request ирэх үед backend рүү ачаалал огцом өгөхөөс сэргийлж, шууд ачаалалд унахын оронд `429 Too Many Requests` буцаадаг боллоо.

## What changed

- `apps/TimeLine/src/lib/api-rate-limit.ts` гэсэн shared rate limit helper нэмсэн
- Дараах API route-ууд дээр rate limit холбосон:
  - `GET /api/hello`
  - `GET /api/db-status`
  - `GET /api/events`
  - `GET /api/rooms`
  - `GET /api/rooms/[roomId]`
  - `POST /api/seed`
- Rate limit хэтэрсэн үед:
  - `429 Too Many Requests` status буцаана
  - `Retry-After` header нэмнэ
  - `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` header-ууд нэмнэ

## Current limits

- `GET /api/rooms`: 60 request / 1 minute / IP
- `GET /api/events`: 60 request / 1 minute / IP
- `GET /api/rooms/[roomId]`: 90 request / 1 minute / IP
- `GET /api/db-status`: 20 request / 1 minute / IP
- `GET /api/hello`: 30 request / 1 minute / IP
- `POST /api/seed`: 5 request / 10 minutes / IP

## Why

Энэ өөрчлөлтийн зорилго нь:
- burst traffic-ийн үед API route-уудыг хамгаалах
- хэт олон request-ээс болж overload болох эрсдэлийг багасгах
- 503 маягийн алдаа руу шууд унахын оронд хяналттай throttle хийх

## Notes

- Одоогийн implementation нь in-memory rate limiter
- Нэг instance дээр ажиллах үед сайн хамгаалалт болно
- Serverless/multi-instance орчинд global distributed limiter биш тул overload эрсдэлийг бууруулна, гэхдээ бүрэн eliminate хийхгүй

## Verification

- `npm exec nx build TimeLine` амжилттай ажилласан
