### PR TITLE
fix(tom): harden club request creation flow

### DIFF
--- a/apps/TOM-web/src/app/api/club-requests/route.ts
+++ b/apps/TOM-web/src/app/api/club-requests/route.ts
@@ -34,6 +34,16 @@ export async function POST(request: NextRequest) {
     const input = parseClubRequestInput(body)
     if (!input) return badRequest('Club request name is required.')
 
+    const clubName = input.clubName.trim()
+    if (clubName.length < 3) return badRequest('Club name must be at least 3 characters.')
+    if (clubName.length > 100) return badRequest('Club name must be at most 100 characters.')
+
+    const existingRequests = await listClubRequests({ q: clubName })
+    const duplicate = existingRequests.find(
+      (r) => r.clubName.trim().toLowerCase() === clubName.toLowerCase()
+    )
+    if (duplicate) return badRequest('A club request with this name already exists.')
+
     const teacherId = typeof body.teacherId === 'string' ? body.teacherId.trim() : ''
     if (!teacherId) return badRequest('teacherId is required.')
 
@@ -46,7 +56,7 @@ export async function POST(request: NextRequest) {
     }
 
     const clubRequest = await upsertClubRequest({
-      clubName: input.clubName,
+      clubName,
       teacherName: teacher.teacherProfileName || teacher.name,
       createdBy: auth.user.id,
       interestCount: 0,


### PR DESCRIPTION
- Validate club name length (min 3, max 100 chars)
- Check for duplicate club name before creating
- createdBy always from session (never client body)
- teacherName always fetched from DB by teacherId