### PR TITLE
fix(tom): use local date instead of UTC for calendar today highlight

### DIFF
--- a/apps/TOM-web/src/app/students/page.tsx
+++ b/apps/TOM-web/src/app/students/page.tsx
@@ -112,7 +112,10 @@ function startOfWeek(date: Date) {
 }
 
 function formatIsoDate(date: Date) {
-  return date.toISOString().slice(0, 10);
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 
 function formatShortDate(date: Date) {


### PR DESCRIPTION
toISOString() returns UTC which causes off-by-one day for UTC+8 timezone.